### PR TITLE
Clean up :ud & add arg to define by ordinal

### DIFF
--- a/Modules/urbandictionary.py
+++ b/Modules/urbandictionary.py
@@ -1,18 +1,35 @@
 # -*- coding: utf-8 -*-
 
 import json
-import urllib2
+from urllib2 import urlopen, quote
 from BotKit import command, stylize
+
+USAGE = ':ud [-num] <word>'
+UD_API = 'http://api.urbandictionary.com/v0/define?term={}'
 
 @command("ud")
 def parse(bot, channel, user, arg):
-    apiurl = 'http://api.urbandictionary.com/v0/define?term=' + urllib2.quote(arg)
-    data = json.load(urllib2.urlopen(apiurl))
-    if len(arg) == 0:
-        bot.msg(channel, 'Usage, :ud <word>')
-    else:
-        if 'no_results' in urllib2.urlopen(apiurl).read():
-            bot.msg(channel, user + ': That word is not defined.')
-        else:
-            definition = stylize.Trunicate(data['list'][0]['definition'].encode('utf-8'), 250)
-            bot.msg(channel, user + ': ' + definition)
+    pos = 0
+    if arg.startswith('-'):
+        try:
+            opt, arg = arg.split(' ', 1)
+            pos = int(opt.strip('-')) - 1  # Zero-based list access.
+        except ValueError:
+            bot.msg(channel, 'Bad argument -- usage, {}'.format(USAGE))
+            return
+    elif not arg:
+        bot.msg(channel, 'Usage, {}'.format(USAGE))
+        return
+
+    url = UD_API.format(quote(arg))
+    data = json.load(urlopen(url))
+
+    if data['result_type'] == 'no_results':
+        bot.msg(channel, '{}: That word is not defined.'.format(user))
+        return
+
+    L = data['list']
+    pos = max(0, min(pos, len(L)-1))  # Ensure argument is within bounds.
+    meaning = L[pos]['definition'].encode('utf-8')
+    truncated = stylize.Truncate(meaning, 250)
+    bot.msg(channel, '{}: {}'.format(user, truncated))


### PR DESCRIPTION
For example:

```
23:12 <@winny> :ud sfw
23:12 <happybot> winny: Safe For Work. Used to describe Internet content that could be viewed in the presence of your boss and colleagues (as opposed to NSFW, Not Safe For Work).
23:12 <@winny> :ud -2 sfw
23:12 <happybot> winny: Safe for work. Something on the [internet] that would be acceptable to view in public.
23:12 <@winny> :ud
23:12 <happybot> Usage, :ud [-num] <word>
23:12 <@winny> :ud -bad
23:12 <happybot> Bad argument -- usage, :ud [-num] <word>
```