### PR TITLE
Report errors with YouTube API using an exception

### DIFF
--- a/Modules/youtube.py
+++ b/Modules/youtube.py
@@ -40,9 +40,20 @@ def parse(bot, channel, user, msg):
 
         resp = requests.get(req_url)
         jo = resp.json()
-        if jo['pageInfo']['totalResults'] < 1:
-            bot.logger.info('Bad youtube id: {}'.format(vid))
-            continue
+
+        if 'error' in jo:
+            error = jo['error']
+            errfmt = 'YouTube API responded with error: {} {} ({})'
+            errmsg = errfmt.format(
+                error['code'],
+                error['message'],
+                error['errors'][0]['reason'],
+            )
+            raise ValueError(errmsg)
+        elif jo['pageInfo']['totalResults'] < 1:
+                bot.logger.info('Bad youtube id: {}'.format(vid))
+                continue
+
         entry = jo['items'][0]
         stats, snippet = entry['statistics'], entry['snippet']
 


### PR DESCRIPTION
Pretty sure the reason it was not working earlier is due to a bad API key or to not enabling the youtube data api on the project. These changes should enable us to find out why it wasn't working.